### PR TITLE
fix too narrow file input + file size rendering below tile

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,11 @@
+.App .react-fine-uploader-gallery-file {
+  width: 145px;
+}
+
+.App .react-fine-uploader-gallery-file-input-container {
+  width: 115px;
+}
+
 .centered {
   width: 500px;
   margin-left: auto;


### PR DESCRIPTION
Great work on this project! I noticed a couple styling issues. Please test out my fixes and let me know if they fix the issue. 

In Chrome, this is the before:

<img width="554" alt="screen shot 2017-02-16 at 10 44 03 pm" src="https://cloud.githubusercontent.com/assets/593312/23052760/78d62236-f499-11e6-9089-7c546f537ef6.png">


...and after:

<img width="547" alt="screen shot 2017-02-16 at 10 39 46 pm" src="https://cloud.githubusercontent.com/assets/593312/23052702/fa531392-f498-11e6-917f-0f8d64edf728.png">


If all looks well, you can probably replace the screenshot from your article with the fixed version (I noticed the issue while reading your awesome post).